### PR TITLE
Fix PWA Install Path for GitHub Pages

### DIFF
--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -38,8 +38,8 @@
   "theme_color": "#3F9B0B",
   "background_color": "#ffffff",
   "display": "standalone",
-  "start_url": "/portfolio-v2/",
-  "scope": "/portfolio-v2/",
+  "start_url": "./",
+  "scope": "./",
   "screenshots": [
     {
       "src": "./screenshot-desktop.png",

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,5 +1,5 @@
 {
-  "id": "/",
+  "id": "/portfolio-v2/",
   "name": "Recep's Portfolio",
   "short_name": "Recep Portfolio",
   "description": "Personal soccer-game-themed portfolio showcasing my development projects and professional experience",
@@ -38,8 +38,8 @@
   "theme_color": "#3F9B0B",
   "background_color": "#ffffff",
   "display": "standalone",
-  "start_url": "/",
-  "scope": "/",
+  "start_url": "/portfolio-v2/",
+  "scope": "/portfolio-v2/",
   "screenshots": [
     {
       "src": "./screenshot-desktop.png",


### PR DESCRIPTION
### **User description**
Closes #54 

### Summary

This PR updates the PWA manifest (`site.webmanifest`) to use the correct subdirectory path (`/portfolio-v2/`) for GitHub Pages deployment.

### Changes

* Updated `id`, `start_url`, and `scope` from `"/"` → `"/portfolio-v2/"`

### Why

Fixes an issue where the PWA was being installed to the root domain (`/`) instead of the correct path, causing it to break on mobile install.

### Result

✅ PWA now installs and launches correctly from `/portfolio-v2/`
✅ Aligns with existing `vite.config.ts`, `package.json`, and router setup


___

### **PR Type**
Bug fix


___

### **Description**
- Fix PWA manifest path for correct installation

- Update `id`, `start_url`, and `scope` values


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>site.webmanifest</strong><dd><code>Update PWA manifest subdirectory paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

public/site.webmanifest

<ul><li>Changed <code>id</code> from "/" to "/portfolio-v2/"<br> <li> Updated <code>start_url</code> to "/portfolio-v2/"<br> <li> Updated <code>scope</code> to "/portfolio-v2/"</ul>


</details>


  </td>
  <td><a href="https://github.com/RecepBorekci/portfolio-v2/pull/55/files#diff-4f2a9d55c0fc669adb0b546c65f11f9f55783a7f4703ccfab620c11a0f5336ad">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

